### PR TITLE
build: Update GRPC version for Apple Silicon

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'dgp_cli=dgp.cli:cli',
     ]},
     include_package_data=True,
-    setup_requires=['cython==0.29.10', 'grpcio==1.21.1', 'grpcio-tools==1.21.1'],
+    setup_requires=['cython==0.29.10', 'grpcio==1.41.0', 'grpcio-tools==1.41.0'],
     install_requires=requirements,
     zip_safe=False,
     python_requires='>=3.6',


### PR DESCRIPTION
The used version of grpc cannot be build on Apple Silicon. This blocks pip-installing the repo via direct links, e.g.
`pip install https://github.com/TRI-ML/dgp/archive/refs/tags/v1.0.zip` on current Macs. This is the standard way for us to install DGP into our docker environment.

Related upstream issue: grpc/grpc#25082